### PR TITLE
added BPM.WIKI

### DIFF
--- a/data.json
+++ b/data.json
@@ -345,6 +345,29 @@
         }
     },
     {
+        "Name": "BPM.WIKI",
+        "Version": "1.0",
+        "URL": "https:\/\/bpm.wiki",
+        "Creator": "process4.biz GmbH",
+        "Platform\/OS": "Browser",
+        "OS": {
+            "Cross-Platform": true,
+            "Windows": false,
+            "Mac": false,
+            "Linux": false,
+            "Unix": false
+        },
+        "BPMN Version": "BPMN 2.0",
+        "First Release": "2019",
+        "Latest Release": "2020",
+        "License": {
+            "free": true,
+            "proprietary": true,
+            "Shareware": false,
+            "Open Source": false
+        }
+    },
+    {
         "Name": "BPMN Sketch Miner",
         "Version": "1.0.9",
         "URL": "https:\/\/design.inf.usi.ch\/bpmn-sketch-miner",


### PR DESCRIPTION
BPM.WIKI intends to provide a dedicated platform to share, collaborate and improve process diagrams. Public content will be available for free, providing maximum visibility and feedback from a growing global community.

Public 2020 release mailing: https://mailchi.mp/b51874e24c54/bpmwiki-is-live-now